### PR TITLE
Remove "Resources" and "Networking" from landing for now

### DIFF
--- a/app/assets/stylesheets/theme.css
+++ b/app/assets/stylesheets/theme.css
@@ -1369,16 +1369,15 @@ span.nav-close:before { content: "\f00d"; }
 }
 .pricing-table h5 { font-weight: 400; }
 .pricing-table small { text-transform:uppercase; font-size:9px; }
-.pricing-table .btn-pricing{ 
+.btn-pricing{ 
 	color: #fff;
-	padding: 0 10px; 
+	padding: 6px 18px; 
 	margin-top: -9px;
-  	  background: none repeat scroll 0 0 green;
-    border-radius: 5px;
-	-webkit-border-radius: 0px;
-	-moz-border-radius: 0px;
+  background: none repeat scroll 0 0 green;
+  border-radius: 5px;
 }
 .btn-pricing:hover { background: rgba(255, 255, 255, 0.3);  color: #fff; }
+.homerow .btn-pricing:hover { background: rgba(96, 96, 96, 0.5);  color: #fff; }
 
 /*************************************************************
 	ACCORDIAN

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -17,6 +17,23 @@
               %br
           .pad25
 
+        .col-sm-12.col-md-6
+          .tile
+            .intro-icon-disc.cont-large
+              %i.fa.fa-pencil-square-o.intro-icon-large
+            %h6
+              %span
+                =link_to("JOIN", memberships_path)
+                %br
+
+            %p
+              Startup Victoria members receive access to a wide range of benefits, from exclusive access to unique events to discounts on essential services and Q&A with community leaders.
+
+            %a.btn.btn-pricing{"href" => new_membership_path}
+              %h5
+                Join Now
+          .pad25
+
         .col-sm-6.col-md-3
           .tile
             .intro-icon-disc.cont-large
@@ -32,32 +49,7 @@
               %br
           .pad25
 
-        .col-sm-6.col-md-3
-          .tile
-            .intro-icon-disc.cont-large
-              %i.fa.fa-users.intro-icon-large
-            %h6
-              %span
-                NETWORKING
-                %br
 
-            %p
-              Speed-dating events (co-founders, mentors) are focused on networking but most networking happens in the regular event calendar.
-          .pad25
-
-
-        .col-sm-6.col-md-3
-          .tile
-            .intro-icon-disc.cont-large
-              %i.fa.fa-book.intro-icon-large
-            %h6
-              %span
-                RESOURCES
-                %br
-
-            %p
-              Startup Victoria wants to lower the cost of paperwork by having standard documents for privacy, terms of service, capital raising etc.
-          .pad25
 
 .home-index#banner
   .jumbotron.container.intro_wrapper


### PR DESCRIPTION
Remove unlinked resources and networking and replace with 2-wide
"Join Now" call to action until we work out what to do long-term.
